### PR TITLE
Update deploy_docs.sh

### DIFF
--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -19,6 +19,6 @@ git config user.email "darwin@yelp.com"
 git config user.name "Darwin S."
 git commit -m 'deploy'
 
-git push -f https://github.com:Yelp/graphql-guidelines.git master:docs
+git push -f https://github.com/Yelp/graphql-guidelines.git main:docs
 
 cd -


### PR DESCRIPTION
This PR updates
- the remote name to `https://github/com/Yelp/graphql-guidelines.git` 
- the **LOCALBRANCHNAME** from `master` to `main`
  - [ref](https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository#renaming-branches)

to solve the build error that is currently seen in GitHub Actions
![source](https://user-images.githubusercontent.com/30559501/147861589-0c9e84d9-04ea-40c2-9265-5943396d6415.png)